### PR TITLE
Add Support for Displaying PowerShell AWS Environment Variables in Chromium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,5 @@
 ## [1.3.0] 2024-02-05
 - Added copy buttons to the popup window
 
-## [1.4.0] 2024-05-13
+## [1.4.0] 2025-05-13
 - Updated to now display PowerShell AWS environment variables, alongside the previously existing credentials for the .aws/credentials file and options for exporting to environment variables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,6 @@
 
 ## [1.3.0] 2024-02-05
 - Added copy buttons to the popup window
+
+## [1.4.0] 2024-05-13
+- Updated to now display PowerShell AWS environment variables, alongside the previously existing credentials for the .aws/credentials file and options for exporting to environment variables.

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 4,
+  "manifest_version": 3,
   "author": "CloudKeeper",
   "homepage_url": "https://app.cloudkeeper.com",
   "name": "CloudKeeper - Credential Helper",

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-  "manifest_version": 3,
+  "manifest_version": 4,
   "author": "CloudKeeper",
   "homepage_url": "https://app.cloudkeeper.com",
   "name": "CloudKeeper - Credential Helper",
   "description": "AWS SSO External AWS Account - STS Keys Generator",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "icons": {
     "32": "icons/icon_crop_128.png",
     "128": "icons/icon_crop_128.png"

--- a/options/changelog.html
+++ b/options/changelog.html
@@ -34,6 +34,8 @@
     <p>Updated the popup to display both credentials for .aws/credentials file and for exporting to environment variables</p>
     <h4>v1.3.0</h4>
     <p>Added copy buttons in the popup window</p>
+    <h4>v1.4.0</h4>
+    <p>Updated to now display PowerShell AWS environment variables, alongside the previously existing credentials for the .aws/credentials file and options for exporting to environment variables.</p>
     <p>&copy 2017-2022 | To The New Pvt. Ltd.</p>
   </body>
 </html>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -125,9 +125,9 @@
     <button class="copy-button" id="copyEnvVariablesButton">Copy Env Variables</button>
 
     <h4>For PowerShell env variables</h4>
-    <p id="posh_env_variables"></p>
+    <p id="pwsh_env_variables"></p>
     <!-- Button to copy PowerShell env variables content -->
-    <button class="copy-button" id="copyPoShEnvVariablesButton">Copy PoSh Env Variables</button>
+    <button class="copy-button" id="copyPwShEnvVariablesButton">Copy PwSh Env Variables</button>
   </div>
   <script src="popup.js"></script>
 </body>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -123,6 +123,11 @@
     <p id="env_variables"></p>
     <!-- Button to copy env variables content -->
     <button class="copy-button" id="copyEnvVariablesButton">Copy Env Variables</button>
+
+    <h4>For PowerShell env variables</h4>
+    <p id="posh_env_variables"></p>
+    <!-- Button to copy PowerShell env variables content -->
+    <button class="copy-button" id="copyPoShEnvVariablesButton">Copy PoSh Env Variables</button>
   </div>
   <script src="popup.js"></script>
 </body>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -10,6 +10,11 @@ document.addEventListener("DOMContentLoaded", function () {
       document.getElementById("env_variables").innerText = data.env_variables;
   });
 
+  chrome.storage.sync.get(["posh_env_variables"], function (data) {
+    if (typeof data.posh_env_variables !== "undefined")
+      document.getElementById("posh_env_variables").innerText = data.posh_env_variables;
+  });
+
   chrome.storage.sync.clear();
 });
 
@@ -43,5 +48,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
   document.getElementById("copyEnvVariablesButton").addEventListener("click", function() {
     copyToClipboardAndUpdateButton('env_variables', 'copyEnvVariablesButton');
+  });
+  
+  document.getElementById("copyPoShEnvVariablesButton").addEventListener("click", function() {
+    copyToClipboardAndUpdateButton('posh_env_variables', 'copyPoShEnvVariablesButton');
   });
 });

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -10,9 +10,9 @@ document.addEventListener("DOMContentLoaded", function () {
       document.getElementById("env_variables").innerText = data.env_variables;
   });
 
-  chrome.storage.sync.get(["posh_env_variables"], function (data) {
-    if (typeof data.posh_env_variables !== "undefined")
-      document.getElementById("posh_env_variables").innerText = data.posh_env_variables;
+  chrome.storage.sync.get(["pwsh_env_variables"], function (data) {
+    if (typeof data.pwsh_env_variables !== "undefined")
+      document.getElementById("pwsh_env_variables").innerText = data.pwsh_env_variables;
   });
 
   chrome.storage.sync.clear();
@@ -50,7 +50,7 @@ document.addEventListener("DOMContentLoaded", function () {
     copyToClipboardAndUpdateButton('env_variables', 'copyEnvVariablesButton');
   });
   
-  document.getElementById("copyPoShEnvVariablesButton").addEventListener("click", function() {
-    copyToClipboardAndUpdateButton('posh_env_variables', 'copyPoShEnvVariablesButton');
+  document.getElementById("copyPwShEnvVariablesButton").addEventListener("click", function() {
+    copyToClipboardAndUpdateButton('pwsh_env_variables', 'copyPwShEnvVariablesButton');
   });
 });

--- a/script.js
+++ b/script.js
@@ -175,7 +175,18 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
               'export AWS_SESSION_TOKEN="',
               data.Credentials.SessionToken,'"'
             ].join('');
-            saveCredentials(docContentEnv, docContentCred);
+            var docContentPoShEnv = [
+              '$Env:AWS_ACCESS_KEY_ID="',
+              data.Credentials.AccessKeyId,
+              '"\n',
+              '$Env:AWS_SECRET_ACCESS_KEY="',
+              data.Credentials.SecretAccessKey,
+              '"\n',
+              '$Env:AWS_SESSION_TOKEN="',
+              data.Credentials.SessionToken, '"'
+            ].join('');
+
+            saveCredentials(docContentEnv, docContentCred, docContentPoShEnv);
           }
         }
       });
@@ -201,17 +212,28 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
         'export AWS_SESSION_TOKEN="',
         data.Credentials.SessionToken,'"'
       ].join('');
+      var docContentPoShEnv = [
+        '$Env:AWS_ACCESS_KEY_ID="',
+        data.Credentials.AccessKeyId,
+        '"\n',
+        '$Env:AWS_SECRET_ACCESS_KEY="',
+        data.Credentials.SecretAccessKey,
+        '"\n',
+        '$Env:AWS_SESSION_TOKEN="',
+        data.Credentials.SessionToken, '"'
+      ].join('');
 
-      saveCredentials(docContentEnv, docContentCred);
+      saveCredentials(docContentEnv, docContentCred, docContentPoShEnv);
     }
   });
 }
 
-function saveCredentials(docContentEnv, docContentCred) {
+function saveCredentials(docContentEnv, docContentCred, docContentPoShEnv) {
   try {
     chrome.storage.sync.clear();
     chrome.storage.sync.set({ credentialsFile: docContentCred });
     chrome.storage.sync.set({ env_variables: docContentEnv });
+    chrome.storage.sync.set({ posh_env_variables: docContentPoShEnv });
   } catch (err) {
     console.log(err.message);
   }

--- a/script.js
+++ b/script.js
@@ -175,7 +175,7 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
               'export AWS_SESSION_TOKEN="',
               data.Credentials.SessionToken,'"'
             ].join('');
-            var docContentPoShEnv = [
+            var docContentPwShEnv = [
               '$Env:AWS_ACCESS_KEY_ID="',
               data.Credentials.AccessKeyId,
               '"\n',
@@ -186,7 +186,7 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
               data.Credentials.SessionToken, '"'
             ].join('');
 
-            saveCredentials(docContentEnv, docContentCred, docContentPoShEnv);
+            saveCredentials(docContentEnv, docContentCred, docContentPwShEnv);
           }
         }
       });
@@ -212,7 +212,7 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
         'export AWS_SESSION_TOKEN="',
         data.Credentials.SessionToken,'"'
       ].join('');
-      var docContentPoShEnv = [
+      var docContentPwShEnv = [
         '$Env:AWS_ACCESS_KEY_ID="',
         data.Credentials.AccessKeyId,
         '"\n',
@@ -223,17 +223,17 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
         data.Credentials.SessionToken, '"'
       ].join('');
 
-      saveCredentials(docContentEnv, docContentCred, docContentPoShEnv);
+      saveCredentials(docContentEnv, docContentCred, docContentPwShEnv);
     }
   });
 }
 
-function saveCredentials(docContentEnv, docContentCred, docContentPoShEnv) {
+function saveCredentials(docContentEnv, docContentCred, docContentPwShEnv) {
   try {
     chrome.storage.sync.clear();
     chrome.storage.sync.set({ credentialsFile: docContentCred });
     chrome.storage.sync.set({ env_variables: docContentEnv });
-    chrome.storage.sync.set({ posh_env_variables: docContentPoShEnv });
+    chrome.storage.sync.set({ pwsh_env_variables: docContentPwShEnv });
   } catch (err) {
     console.log(err.message);
   }


### PR DESCRIPTION
Updated to now display PowerShell AWS environment variables, alongside the previously existing credentials for the .aws/credentials file and options for exporting to environment variables.