### PR TITLE
 Add Support for Displaying PowerShell AWS Environment Variables in Firefox 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,6 @@
 
 ## [1.3.0] 2024-02-05
 - Added copy button
+
+## [1.4.0] 2025-05-13
+- Updated to now display PowerShell AWS environment variables, alongside the previously existing credentials for the .aws/credentials file and options for exporting to environment variables.

--- a/background/script.js
+++ b/background/script.js
@@ -2,7 +2,6 @@ var FileName = "credentials";
 var DebugLogs = true;
 var RoleArns = {};
 var LF = "\n";
-
 browser.webNavigation.onBeforeNavigate.addListener((details) => {
   console.log(
     "Keeping alive -CloudKeeper - Credential Helper - Service Worker"
@@ -174,7 +173,18 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
               'export AWS_SESSION_TOKEN="',
               data.Credentials.SessionToken,'"'
             ].join('');
-            saveCredentials(docContentEnv, docContentCred);
+            var docContentPoShEnv = [
+              '$Env:AWS_ACCESS_KEY_ID="',
+              data.Credentials.AccessKeyId,
+              '"\n',
+              '$Env:AWS_SECRET_ACCESS_KEY="',
+              data.Credentials.SecretAccessKey,
+              '"\n',
+              '$Env:AWS_SESSION_TOKEN="',
+              data.Credentials.SessionToken, '"'
+            ].join('');
+
+            saveCredentials(docContentEnv, docContentCred, docContentPoShEnv);
           }
         }
       });
@@ -200,17 +210,28 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
         'export AWS_SESSION_TOKEN="',
         data.Credentials.SessionToken,'"'
       ].join('');
+      var docContentPoShEnv = [
+        '$Env:AWS_ACCESS_KEY_ID="',
+        data.Credentials.AccessKeyId,
+        '"\n',
+        '$Env:AWS_SECRET_ACCESS_KEY="',
+        data.Credentials.SecretAccessKey,
+        '"\n',
+        '$Env:AWS_SESSION_TOKEN="',
+        data.Credentials.SessionToken, '"'
+      ].join('');
 
-      saveCredentials(docContentEnv, docContentCred);
+      saveCredentials(docContentEnv, docContentCred, docContentPoShEnv);
     }
   });
 }
 
-function saveCredentials(docContentEnv, docContentCred) {
+function saveCredentials(docContentEnv, docContentCred, docContentPoShEnv) {
   try {
     browser.storage.sync.clear();
     browser.storage.sync.set({ credentialsFile: docContentCred });
     browser.storage.sync.set({ env_variables: docContentEnv });
+    browser.storage.sync.set({ posh_env_variables: docContentPoShEnv });
   } catch (err) {
     console.log(err.message);
   }

--- a/background/script.js
+++ b/background/script.js
@@ -173,7 +173,7 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
               'export AWS_SESSION_TOKEN="',
               data.Credentials.SessionToken,'"'
             ].join('');
-            var docContentPoShEnv = [
+            var docContentPwShEnv = [
               '$Env:AWS_ACCESS_KEY_ID="',
               data.Credentials.AccessKeyId,
               '"\n',
@@ -184,7 +184,7 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
               data.Credentials.SessionToken, '"'
             ].join('');
 
-            saveCredentials(docContentEnv, docContentCred, docContentPoShEnv);
+            saveCredentials(docContentEnv, docContentCred, docContentPwShEnv);
           }
         }
       });
@@ -210,7 +210,7 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
         'export AWS_SESSION_TOKEN="',
         data.Credentials.SessionToken,'"'
       ].join('');
-      var docContentPoShEnv = [
+      var docContentPwShEnv = [
         '$Env:AWS_ACCESS_KEY_ID="',
         data.Credentials.AccessKeyId,
         '"\n',
@@ -221,17 +221,17 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
         data.Credentials.SessionToken, '"'
       ].join('');
 
-      saveCredentials(docContentEnv, docContentCred, docContentPoShEnv);
+      saveCredentials(docContentEnv, docContentCred, docContentPwShEnv);
     }
   });
 }
 
-function saveCredentials(docContentEnv, docContentCred, docContentPoShEnv) {
+function saveCredentials(docContentEnv, docContentCred, docContentPwShEnv) {
   try {
     browser.storage.sync.clear();
     browser.storage.sync.set({ credentialsFile: docContentCred });
     browser.storage.sync.set({ env_variables: docContentEnv });
-    browser.storage.sync.set({ posh_env_variables: docContentPoShEnv });
+    browser.storage.sync.set({ pwsh_env_variables: docContentPwShEnv });
   } catch (err) {
     console.log(err.message);
   }

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "homepage_url": "https://app.cloudkeeper.com",
   "name": "CloudKeeper - Credential Helper",
   "description": "AWS SSO External AWS Account - STS Keys Generator",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "icons": {
     "32": "icons/icon_crop_128.png",
     "128": "icons/icon_crop_128.png"

--- a/options/changelog.html
+++ b/options/changelog.html
@@ -36,6 +36,9 @@
     <h4>v1.3.0</h4>
     <p>Added copy buttons to the popup.</p>
     <br>
-    <p>&copy 2017-2022 | To The New Pvt. Ltd.</p>
+    <h4>v1.4.0</h4>
+    <p>Updated to now display PowerShell AWS environment variables, alongside the previously existing credentials for the .aws/credentials file and options for exporting to environment variables.</p>
+    <br>
+    <p>&copy 2017-2022 | CloudKeeper India Pvt. Ltd.</p>
   </body>
 </html>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -125,9 +125,9 @@
     <button class="copy-button" id="copyEnvVariablesButton">Copy Env Variables</button>
 
     <h4>For PowerShell env variables</h4>
-    <p id="posh_env_variables"></p>
+    <p id="pwsh_env_variables"></p>
     <!-- Button to copy PowerShell env variables content -->
-    <button class="copy-button" id="copyPoShEnvVariablesButton">Copy PoSh Env Variables</button>
+    <button class="copy-button" id="copyPwShEnvVariablesButton">Copy PwSh Env Variables</button>
   </div>
   <script src="popup.js"></script>
 </body>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -123,6 +123,11 @@
     <p id="env_variables"></p>
     <!-- Button to copy env variables content -->
     <button class="copy-button" id="copyEnvVariablesButton">Copy Env Variables</button>
+
+    <h4>For PowerShell env variables</h4>
+    <p id="posh_env_variables"></p>
+    <!-- Button to copy PowerShell env variables content -->
+    <button class="copy-button" id="copyPoShEnvVariablesButton">Copy PoSh Env Variables</button>
   </div>
   <script src="popup.js"></script>
 </body>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -10,9 +10,9 @@ document.addEventListener("DOMContentLoaded", function () {
       document.getElementById("env_variables").innerText = data.env_variables;
   });
 
-  browser.storage.sync.get(["posh_env_variables"], function (data) {
-    if (typeof data.posh_env_variables !== "undefined")
-      document.getElementById("posh_env_variables").innerText = data.posh_env_variables;
+  browser.storage.sync.get(["pwsh_env_variables"], function (data) {
+    if (typeof data.pwsh_env_variables !== "undefined")
+      document.getElementById("pwsh_env_variables").innerText = data.pwsh_env_variables;
   });
 
   browser.storage.sync.clear();
@@ -50,7 +50,7 @@ document.addEventListener("DOMContentLoaded", function () {
     copyToClipboardAndUpdateButton('env_variables', 'copyEnvVariablesButton');
   });
   
-  document.getElementById("copyPoShEnvVariablesButton").addEventListener("click", function() {
-    copyToClipboardAndUpdateButton('posh_env_variables', 'copyPoShEnvVariablesButton');
+  document.getElementById("copyPwShEnvVariablesButton").addEventListener("click", function() {
+    copyToClipboardAndUpdateButton('pwsh_env_variables', 'copyPwShEnvVariablesButton');
   });
 });

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -2,14 +2,19 @@
 document.addEventListener("DOMContentLoaded", function () {
   browser.storage.sync.get(["credentialsFile"], function (data) {
     if (typeof data.credentialsFile !== "undefined")
-      document.getElementById("credentialsFile").innerText =
-        data.credentialsFile;
+      document.getElementById("credentialsFile").innerText = data.credentialsFile;
   });
+
   browser.storage.sync.get(["env_variables"], function (data) {
     if (typeof data.env_variables !== "undefined")
-      document.getElementById("env_variables").innerText =
-        data.env_variables;
+      document.getElementById("env_variables").innerText = data.env_variables;
   });
+
+  browser.storage.sync.get(["posh_env_variables"], function (data) {
+    if (typeof data.posh_env_variables !== "undefined")
+      document.getElementById("posh_env_variables").innerText = data.posh_env_variables;
+  });
+
   browser.storage.sync.clear();
 });
 
@@ -43,5 +48,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
   document.getElementById("copyEnvVariablesButton").addEventListener("click", function() {
     copyToClipboardAndUpdateButton('env_variables', 'copyEnvVariablesButton');
+  });
+  
+  document.getElementById("copyPoShEnvVariablesButton").addEventListener("click", function() {
+    copyToClipboardAndUpdateButton('posh_env_variables', 'copyPoShEnvVariablesButton');
   });
 });


### PR DESCRIPTION


Updated to now display PowerShell AWS environment variables, alongside the previously existing credentials for the .aws/credentials file and options for exporting to environment variables.
