### PR TITLE
Add Support for Displaying PowerShell AWS Environment Variables in Firefox

### DIFF
--- a/background/script.js
+++ b/background/script.js
@@ -173,7 +173,7 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
               'export AWS_SESSION_TOKEN="',
               data.Credentials.SessionToken,'"'
             ].join('');
-            var docContentPoShEnv = [
+            var docContentPwShEnv = [
               '$Env:AWS_ACCESS_KEY_ID="',
               data.Credentials.AccessKeyId,
               '"\n',
@@ -184,7 +184,7 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
               data.Credentials.SessionToken, '"'
             ].join('');
 
-            saveCredentials(docContentEnv, docContentCred, docContentPoShEnv);
+            saveCredentials(docContentEnv, docContentCred, docContentPwShEnv);
           }
         }
       });
@@ -210,7 +210,7 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
         'export AWS_SESSION_TOKEN="',
         data.Credentials.SessionToken,'"'
       ].join('');
-      var docContentPoShEnv = [
+      var docContentPwShEnv = [
         '$Env:AWS_ACCESS_KEY_ID="',
         data.Credentials.AccessKeyId,
         '"\n',
@@ -221,17 +221,17 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
         data.Credentials.SessionToken, '"'
       ].join('');
 
-      saveCredentials(docContentEnv, docContentCred, docContentPoShEnv);
+      saveCredentials(docContentEnv, docContentCred, docContentPwShEnv);
     }
   });
 }
 
-function saveCredentials(docContentEnv, docContentCred, docContentPoShEnv) {
+function saveCredentials(docContentEnv, docContentCred, docContentPwShEnv) {
   try {
     browser.storage.sync.clear();
     browser.storage.sync.set({ credentialsFile: docContentCred });
     browser.storage.sync.set({ env_variables: docContentEnv });
-    browser.storage.sync.set({ posh_env_variables: docContentPoShEnv });
+    browser.storage.sync.set({ pwsh_env_variables: docContentPwShEnv });
   } catch (err) {
     console.log(err.message);
   }

--- a/options/changelog.html
+++ b/options/changelog.html
@@ -39,6 +39,6 @@
     <h4>v1.4.0</h4>
     <p>Updated to now display PowerShell AWS environment variables, alongside the previously existing credentials for the .aws/credentials file and options for exporting to environment variables.</p>
     <br>
-    <p>&copy 2017-2022 | CloudKeeper India Pvt. Ltd.</p>
+    <p>&copy 2017-2025 | CloudKeeper India Pvt. Ltd.</p>
   </body>
 </html>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -125,9 +125,9 @@
     <button class="copy-button" id="copyEnvVariablesButton">Copy Env Variables</button>
 
     <h4>For PowerShell env variables</h4>
-    <p id="posh_env_variables"></p>
+    <p id="pwsh_env_variables"></p>
     <!-- Button to copy PowerShell env variables content -->
-    <button class="copy-button" id="copyPoShEnvVariablesButton">Copy PoSh Env Variables</button>
+    <button class="copy-button" id="copyPwShEnvVariablesButton">Copy PwSh Env Variables</button>
   </div>
   <script src="popup.js"></script>
 </body>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -10,9 +10,9 @@ document.addEventListener("DOMContentLoaded", function () {
       document.getElementById("env_variables").innerText = data.env_variables;
   });
 
-  browser.storage.sync.get(["posh_env_variables"], function (data) {
-    if (typeof data.posh_env_variables !== "undefined")
-      document.getElementById("posh_env_variables").innerText = data.posh_env_variables;
+  browser.storage.sync.get(["pwsh_env_variables"], function (data) {
+    if (typeof data.pwsh_env_variables !== "undefined")
+      document.getElementById("pwsh_env_variables").innerText = data.pwsh_env_variables;
   });
 
   browser.storage.sync.clear();
@@ -50,7 +50,7 @@ document.addEventListener("DOMContentLoaded", function () {
     copyToClipboardAndUpdateButton('env_variables', 'copyEnvVariablesButton');
   });
   
-  document.getElementById("copyPoShEnvVariablesButton").addEventListener("click", function() {
-    copyToClipboardAndUpdateButton('posh_env_variables', 'copyPoShEnvVariablesButton');
+  document.getElementById("copyPwShEnvVariablesButton").addEventListener("click", function() {
+    copyToClipboardAndUpdateButton('pwsh_env_variables', 'copyPwShEnvVariablesButton');
   });
 });


### PR DESCRIPTION
Updated to now display PowerShell AWS environment variables, alongside the previously existing credentials for the .aws/credentials file and options for exporting to environment variables.
